### PR TITLE
Removing deprecated salt option

### DIFF
--- a/www/app/Controllers/UserController.php
+++ b/www/app/Controllers/UserController.php
@@ -65,7 +65,6 @@ class UserController extends BaseController
         }
 
         $options = [
-            'salt' => uniqid(mt_rand(), true),
             'cost' => 12
         ];
         


### PR DESCRIPTION
When registering a new user, the following exception occurs:
```
CRITICAL - 2022-07-30 20:14:03 --> password_hash(): Use of the 'salt' option to password_hash is deprecated
#0 [internal function]: CodeIgniter\Debug\Exceptions->errorHandler(8192, 'password_hash()...', '/var/www/html/a...', 73, Array)
#1 /var/www/html/app/Controllers/UserController.php(73): password_hash('123456', 1, Array)
#2 /var/www/html/system/CodeIgniter.php(936): App\Controllers\UserController->register_v1()
#3 /var/www/html/system/CodeIgniter.php(432): CodeIgniter\CodeIgniter->runController(Object(App\Controllers\UserController))
#4 /var/www/html/system/CodeIgniter.php(333): CodeIgniter\CodeIgniter->handleRequest(NULL, Object(Config\Cache), false)
#5 /var/www/html/index.php(45): CodeIgniter\CodeIgniter->run()
```

Removing the optional fixes the issue